### PR TITLE
Formatting peaks and siblings to constant size

### DIFF
--- a/packages/core/__tests__/core.test.ts
+++ b/packages/core/__tests__/core.test.ts
@@ -5,12 +5,12 @@ import MMRInMemoryStore from "@herodotus_dev/mmr-memory";
 const store = new MMRInMemoryStore();
 const hasher = new StarkPedersenHasher();
 
-describe("precomputation", () => {
+describe("Core: core functionalities", () => {
   let mmr: CoreMMR;
   const rootAt6Leaves = "0x04a1ae364258121690285af43cd4ee91adfd6a8647211748657d8e66835a20a1";
 
   it("should compute parent tree", async () => {
-    mmr = new CoreMMR(store, hasher as any);
+    mmr = new CoreMMR(store, hasher);
     await mmr.append("1");
     await mmr.append("2");
     await mmr.append("3");

--- a/packages/core/__tests__/formatting.test.ts
+++ b/packages/core/__tests__/formatting.test.ts
@@ -1,0 +1,78 @@
+import CoreMMR, { AppendResult } from "../src";
+import { StarkPedersenHasher } from "@herodotus_dev/mmr-hashes";
+import MMRInMemoryStore from "@herodotus_dev/mmr-memory";
+
+describe("Core: formatting", () => {
+  let mmr: CoreMMR;
+
+  beforeAll(async () => {
+    mmr = new CoreMMR(new MMRInMemoryStore(), new StarkPedersenHasher());
+    await mmr.append("1");
+    await mmr.append("2");
+    await mmr.append("3");
+    await mmr.append("4");
+    await mmr.append("5");
+  });
+
+  it("Should properly format the proof", async () => {
+    const proof = await mmr.getProof(4);
+
+    const actualProofSiblingsHashesLength = proof.siblingsHashes.length;
+    const actualProofPeaksLength = proof.peaksHashes.length;
+
+    const nullValue = "0xffff";
+    const expectedFormattedProofSiblingHashesLength = 4;
+    const expectedFormattedProofPeaksLength = 4;
+
+    const proofFormatted = await mmr.getProof(4, {
+      proof: {
+        outputSize: expectedFormattedProofSiblingHashesLength,
+        nullValue,
+      },
+      peaks: {
+        outputSize: expectedFormattedProofPeaksLength,
+        nullValue,
+      },
+    });
+
+    const expectedNullValuesInProofSiblingsHashes =
+      proofFormatted.siblingsHashes.length - actualProofSiblingsHashesLength;
+    const expectedNullValuesInProofPeaks = proofFormatted.peaksHashes.length - actualProofPeaksLength;
+
+    const nullSiblingsHashesInProofFormatted = proofFormatted.siblingsHashes.filter((hash) => hash === nullValue);
+    expect(nullSiblingsHashesInProofFormatted.length).toBe(expectedNullValuesInProofSiblingsHashes);
+
+    const nullPeaksInProofFormatted = proofFormatted.peaksHashes.filter((hash) => hash === nullValue);
+    expect(nullPeaksInProofFormatted.length).toBe(expectedNullValuesInProofPeaks);
+  });
+
+  it("Should properly format the peaks", async () => {
+    const peaks = await mmr.getPeaks();
+
+    const actualPeaksLength = peaks.length;
+    const nullValue = "0xffff";
+    const expectedFormattedPeaksLength = 4;
+
+    const peaksFormatted = await mmr.getPeaks({
+      outputSize: expectedFormattedPeaksLength,
+      nullValue,
+    });
+
+    const expectedNullValuesInPeaks = peaksFormatted.length - actualPeaksLength;
+    const nullPeaksInPeaksFormatted = peaksFormatted.filter((hash) => hash === nullValue);
+    expect(nullPeaksInPeaksFormatted.length).toBe(expectedNullValuesInPeaks);
+  });
+
+  it("Should succesfully verify a formatted proof", async () => {
+    const formattingOptions = {
+      nullValue: "0xffff",
+      outputSize: 4,
+    };
+
+    const proof = await mmr.getProof(4, { peaks: formattingOptions, proof: formattingOptions });
+
+    // TODO explain why 3 is the value
+    const isValid = await mmr.verifyProof(proof, "3", { peaks: formattingOptions, proof: formattingOptions });
+    expect(isValid).toBe(true);
+  });
+});

--- a/packages/core/__tests__/precomputation.test.ts
+++ b/packages/core/__tests__/precomputation.test.ts
@@ -10,7 +10,7 @@ describe("precomputation", () => {
   const rootAt6Leaves = "0x04a1ae364258121690285af43cd4ee91adfd6a8647211748657d8e66835a20a1";
 
   beforeEach(async () => {
-    mmr = new CoreMMR(store, hasher as any);
+    mmr = new CoreMMR(store, hasher);
     await mmr.append("1");
     await mmr.append("2");
     await mmr.append("3");

--- a/packages/core/src/types/formatting.ts
+++ b/packages/core/src/types/formatting.ts
@@ -1,0 +1,37 @@
+interface FormattingOptions {
+  outputSize: number;
+  nullValue: string;
+}
+
+export type ProofFormattingOptions = FormattingOptions;
+export type PeaksFormattingOptions = FormattingOptions;
+
+export function validateFormattingOptions(options: FormattingOptions) {
+  if (!options.nullValue.startsWith("0x")) {
+    throw new Error("Formatting options: nullValue must be a hex string");
+  }
+
+  if (Number.isNaN(parseInt(options.nullValue, 16))) {
+    throw new Error("Formatting options: nullValue must be a hex string");
+  }
+}
+
+export function formatPeaks(peaks: string[], formattingOpts: PeaksFormattingOptions): string[] {
+  if (peaks.length > formattingOpts.outputSize) {
+    throw new Error("Formatting: Expected peaks output size is smaller than the actual size");
+  }
+
+  const expectedPeaksSizeRemainder = formattingOpts.outputSize - peaks.length;
+  const peaksNullValues = Array<string>(expectedPeaksSizeRemainder).fill(formattingOpts.nullValue);
+  return peaks.concat(peaksNullValues);
+}
+
+export function formatProof(siblingsHashes: string[], formattingOpts: ProofFormattingOptions): string[] {
+  if (siblingsHashes.length > formattingOpts.outputSize) {
+    throw new Error("Formatting: Expected proof output size is smaller than the actual size");
+  }
+
+  const expectedProofSizeRemainder = formattingOpts.outputSize - siblingsHashes.length;
+  const proofNullValues = Array<string>(expectedProofSizeRemainder).fill(formattingOpts.nullValue);
+  return siblingsHashes.concat(proofNullValues);
+}

--- a/packages/core/src/types/hasher.ts
+++ b/packages/core/src/types/hasher.ts
@@ -11,7 +11,7 @@ export const defaultHasherOptions: HasherOptions = {
 export type HexString = string;
 
 export abstract class IHasher {
-  constructor(protected readonly options: HasherOptions = defaultHasherOptions) {}
+  constructor(public readonly options: HasherOptions = defaultHasherOptions) {}
 
   /**
    *

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -3,3 +3,4 @@ export * from "./hasher";
 export * from "./accumulator";
 export * from "./metadata";
 export * from "./proof";
+export * from './formatting'


### PR DESCRIPTION
This PR introduces a new optional parameter to methods such as:
* `getProof`
* `verifyProof`
* `getPeaks`
Such parameter once provided will make the library append suffixes to the peaks and sibling of proof in order to make them constant size.
Such feature is useful when these proofs need to be verified in e.g. circuits.